### PR TITLE
3828: Add posibility to use only localId in getObject request

### DIFF
--- a/lib/request/TingClientObjectRequest.php
+++ b/lib/request/TingClientObjectRequest.php
@@ -11,12 +11,13 @@ class TingClientObjectRequest extends TingClientRequest {
   protected $allRelations;
   protected $format;
   protected $id;
-  protected $localId;
+  protected $localIds;
   protected $relationData;
   protected $identifiers;
   protected $profile;
   protected $outputType;
   protected $objectFormat;
+  protected $fausts;
 
   public function setObjectFormat($objectFormat) {
     $this->objectFormat = $objectFormat;
@@ -64,12 +65,16 @@ class TingClientObjectRequest extends TingClientRequest {
     $this->format = $format;
   }
 
-  public function getLocalId() {
-    return $this->localId;
+  public function getLocalIds() {
+    return $this->localIds;
   }
 
   public function setLocalId($localId) {
-    $this->localId = $localId;
+    $this->localIds = array($localId);
+  }
+
+  public function setLocalIds($localIds) {
+    $this->localIds = $localIds;
   }
 
   public function getObjectIds() {
@@ -104,17 +109,12 @@ class TingClientObjectRequest extends TingClientRequest {
       $this->setParameter('format', 'dkabm');
     }
 
-    // Determine which id to use and the corresponding index
+    // Determine which id to use.
     if ($this->identifiers) {
       $this->setParameter('identifier', $this->identifiers);
     }
-
-    // If we have both localId and ownerId, combine them to get
-    elseif ($this->getAgency() && $this->localId) {
-      $this->setParameter('identifier', implode('|', array(
-        $this->localId,
-        $this->getAgency(),
-      )));
+    elseif ($this->localIds) {
+      $this->setParameter('localIdentifier', $this->localIds);
     }
 
     $methodParameterMap = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3828

Related PR: https://github.com/ding2/ding2/pull/1261

#### Description
According to the documentation at https://opensearch.addi.dk/b3.5_5.0/ Opensearch getObject supports two identifiers: 

- identifier: expected to be a pid with an owner used as namespace.
- localIdentifier: expected to be a local id/faust of library material.

In the current state the client constructs a pid and uses identifier in all cases. When pid/pids is passed in the $identifier property it correctly uses identifier parameter in request. If a localId is passed it **tries** to construct what looks like a pid, using the agencyId property, and also use identifier parameter.

It doesn't really make sense to only use pid in all cases and we have a situation in https://github.com/ding2/ding2/pull/1261 where we actually need to use localIdentifier, to get the correct namespace for local fausts. 

Also, the pid it tries to construct appears to be incorrect. For example for localId 42182184 and agencyId 763000 it creates the following parameter in the SOAP-request:

`<ns1:identifier>42182184|763000</ns1:identifier>`

I tested it and it gives an error on https://opensearch.addi.dk/b3.5_5.0/.

In any case it seems to also be easier to just use the locak localIdentifier.

The PR also introduce new property $localIds to TingClientObjectRequest to make it possible to request multiple localIds, like it's already possible with $identifiers.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.