### PR TITLE
3936: Handle unknown/missing/inaccessible object in getObject

### DIFF
--- a/lib/request/TingClientObjectRequest.php
+++ b/lib/request/TingClientObjectRequest.php
@@ -7,6 +7,12 @@
  * as a subclass, even though it is a different request type.
  */
 class TingClientObjectRequest extends TingClientRequest {
+  // When getObject is unable to find an object it will return an object with
+  // this title. So to avoid returning "fake" objects with this title and no
+  // data, we will have to look for this prefix in the titles of objects
+  // returned from getObject.
+  const MISSING_OBJECT_TITLE = 'Error: unknown/missing/inaccessible record:';
+
   protected $agency;
   protected $allRelations;
   protected $format;
@@ -148,12 +154,14 @@ class TingClientObjectRequest extends TingClientRequest {
     $objects = array();
     foreach ($response->collections as $collection) {
       foreach ($collection->objects as $object) {
-        $objects[$object->id] = $object;
+        $title = isset($object->record['dc:title'][''][0]) ? $object->record['dc:title'][''][0] : '';
+        // Ensure that getObject was able to finde the object.
+        if (strpos($title, self::MISSING_OBJECT_TITLE) !== 0) {
+          $objects[$object->id] = $object;
+        }
       }
     }
 
-    if (!empty($objects)) {
-      return $objects;
-    }
+    return $objects;
   }
 }


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3936

A side effect of using getObject to fetch multiple objects instead of a search-request, is that it will return records with the title prefix:

"Error: unknown/missing/inaccessible record:"

So to avoid generating "fake" objects and passing them to the system, we should look for these titles when generating objects.

Also, now TingClientObjectRequest will now return an array in all cases, even if no objects was found (an empty array). This fixes some notices:

Related to: https://github.com/ding2/ding2/pull/1293
