### PR TITLE
4060: Ensured that the request object is not modified

### DIFF
--- a/lib/request/TingClientRequest.php
+++ b/lib/request/TingClientRequest.php
@@ -97,7 +97,8 @@ abstract class TingClientRequest {
    * @throws \TingClientException
    */
   public function execute(TingClientRequestAdapter $adapter) {
-    return $adapter->execute($this->getRequest());
+    $clone = clone $this;
+    return $adapter->execute($clone->getRequest());
   }
 
   /**
@@ -110,7 +111,8 @@ abstract class TingClientRequest {
    * @throws \TingClientException
    */
   public function parseResponse($response) {
-    if ($this->getRequest() instanceof TingFulltextRequest) {
+    $clone = clone $this;
+    if ($clone->getRequest() instanceof TingFulltextRequest) {
       // Objectify response since processResponse() awaiting stdClass.
       return $this->processResponse((object) $response);
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4060

#### Description

When executing/processing an search request the request is modified which will create a new cache id in the opensearch client.

To prevent this a clone of the request is used.

#### Screenshot of the result

![screen shot 2019-01-11 at 13 47 12](https://user-images.githubusercontent.com/111397/51036543-b7483900-15ad-11e9-8c56-296b2cb782cd.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).

#### Additional comments or questions

No comments