### PR TITLE
4139: Minor logic changes and remove hardcode value

### DIFF
--- a/lib/request/TingClientCollectionRequest.php
+++ b/lib/request/TingClientCollectionRequest.php
@@ -23,7 +23,6 @@ class TingClientCollectionRequest extends TingClientSearchRequest {
   public function getRequest() {
     $this->setQuery('rec.id=' . $this->id);
     $this->setAgency($this->agency);
-    $this->setAllObjects(true);
     $this->setNumResults(1);
 
     return parent::getRequest();
@@ -37,4 +36,3 @@ class TingClientCollectionRequest extends TingClientSearchRequest {
     }
   }
 }
-

--- a/lib/request/TingClientSearchRequest.php
+++ b/lib/request/TingClientSearchRequest.php
@@ -71,7 +71,8 @@ class TingClientSearchRequest extends TingClientRequest {
 
     foreach ($methodParameterMap as $method => $parameter) {
       $getter = 'get' . ucfirst($method);
-      if ($value = $this->$getter()) {
+      // Add all non-NULL parameters.
+      if (NULL !== ($value = $this->$getter())) {
         $this->setParameter($parameter, $value);
       }
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4139

#### Description

During work with eReolen.dk and in analysing cache issues we found this minor strange things in the client.

* When making an getObject request with collection ture in opensearch.client.inc the allObject is set to false, but will always be overriden in the client.
*  If a search request has an boolean parameter set to false it will not be set.

#### Screenshot of the result

No screenshot

#### Checklist

No test exists in the client repos, so check list removed.

#### Additional comments or questions

Linked to https://github.com/ding2/ding2/pull/1364