### PR TITLE
4126: Fix reference in TingCollectionRequest::getObjectId()

### DIFF
--- a/lib/request/TingClientCollectionRequest.php
+++ b/lib/request/TingClientCollectionRequest.php
@@ -5,7 +5,7 @@ class TingClientCollectionRequest extends TingClientSearchRequest {
   protected $agency;
 
   public function getObjectId() {
-    return $id;
+    return $this->id;
   }
 
   public function setObjectId($id) {


### PR DESCRIPTION
Currently it's impossible to get the id of a TingCollectionRequest, because the get method is not using `$this->` failing to reference the property.

I need to get this id in: https://github.com/ding2/ding2/pull/1508