### PR TITLE
4212: Handle Opensearch missing object error

### DIFF
--- a/lib/request/TingClientObjectRequest.php
+++ b/lib/request/TingClientObjectRequest.php
@@ -147,6 +147,12 @@ class TingClientObjectRequest extends TingClientRequest {
     // error objects, log an expection and just not return anything for this ID.
     // Then we may return an empty array, but this is the standard behavior for
     // functions returning multiple objects/entities.
+    // We handle this here in TingObjectRequest since these errors are specific
+    // to getObject requests. Note that we do it before passing the response to
+    // TingClientSearchRequest for further processing, so we get a chance to log
+    // an error. Also, we can remove the error objects from search result, so
+    // that TingClientSearchRequest doesn't waste time parsing error objects
+    // that we don't need anyway.
     if (!empty($response->searchResponse->result->hitCount)) {
       if (!empty($response->searchResponse->result->searchResult)) {
         $search_result = &$response->searchResponse->result->searchResult;

--- a/lib/request/TingClientRequest.php
+++ b/lib/request/TingClientRequest.php
@@ -125,29 +125,6 @@ abstract class TingClientRequest {
       throw new TingClientException('Unexpected JSON response: ' . var_export($response, TRUE));
     }
 
-    // Find error messages in the response - data well v3. The data well return
-    // objects with only title elements that contains an error message (not the
-    // title), but the hit count is zero on these error objects. I may have
-    // been fixed on later version of the data well (3.0+), but it have to be
-    // tested.
-    if (!empty($response->searchResponse->result->hitCount)) {
-      if (!empty($response->searchResponse->result->searchResult)) {
-        $search_result = $response->searchResponse->result->searchResult;
-        foreach ($search_result as $index => $result) {
-          foreach ($result->collection->object as $object) {
-            if (isset($object->error)) {
-              // As the code have change to get more than on object in getObject
-              // request to the data well. The whole processing should not stop
-              // do to a single missing object from the data well. So removed
-              // the error'ed object at continue processing.
-              unset($search_result[$index]);
-              watchdog_exception('ting', new TingClientException('Unexpected error message in response: ' . var_export($response, TRUE)));
-            }
-          }
-        }
-      }
-    }
-
     return $this->processResponse($response);
   }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4212 

This PR should be merged together with: https://github.com/ding2/ding2/pull/1551

#### Description

Handle Opensearch missing objects errors.

Since version 5.2 these errors are now returned as elements (se screenshot below).

In Opensearch versions < 5.2 the missing object errors was returned as real objects with the error message in the title. In this PR we maintain compatibility with this by looking for these cases and construct the error message ourself. 

IMO the correct place to handle this is not in TingClientRequest but in TingClientObjectRequest, since these errors will only appear on getObject request, where a specific object ID was requested but not found in the data well. See the documentation part about Release notes 5.2: https://opensource.dbc.dk/services/open-search-web-service.

You can not have missing objects in a search request or collection request (which is just a search request). If you search for a specific rec.id with a collection request, it will just return nothing like a normal search request where nothing was found. And errors on search and collection requests are already handled in [TingClientSearchRequest](https://github.com/ding2/ting-client/blob/master/lib/request/TingClientSearchRequest.php#L227)

There was a small change in the data structure that seems to be a result of the new error element. From commit message:

> The error element added to objects in opensearch version 5.2+ is
> changing the result of the XML parsing: for objects with an
> error element the object will not be an array like with "normal"
> objects without error element, but instead the object itself. In
> earlier versions, where the error is returned as real objects,
> the object is still an array. So to be able to handle errors in
> all versions, we normalize it here. There seems to be no
> difference in the WSDL and XSD, so the new of handling errors
> on objects in 5.2+ must be the cause of this change in data
> structure. For more info see:

As mentioned i can not spot any differences in WSDL and XSD:

https://opensearch.addi.dk/b3.5_5.0/?wsdl
https://opensearch.addi.dk/b3.5_5.0/opensearch.xsd
https://opensearch.addi.dk/b3.5_5.2/?wsdl
https://opensearch.addi.dk/b3.5_5.2/opensearch.xsd

So my guess is that it's purely the change in XML-structure that is causing it to be parsed differently. DBC may need to have a look at it, as it is not optimal to have changing data structure and it may cause notices/warnings/errors in code that expects an array, but now recieves an object instead, when getObject wasn't able to find anything for an ID.

In our case however it's easily handled by [normalizing to object](https://github.com/ding2/ting-client/pull/31/files#diff-177da93c4ff7fe7e037aba799ab3d0b6R172)

#### Opensearch version 5.2 missing object error

![4212-now-error-element](https://user-images.githubusercontent.com/5011234/66663040-3f956080-ec4a-11e9-99e3-697160c262eb.PNG)

#### Opensearch versions < 5.2 missing object error

![4212-error-title](https://user-images.githubusercontent.com/5011234/66663812-ab2bfd80-ec4b-11e9-8000-1f7d185f249a.PNG)