### PR TITLE
Fix watchdog logging

### DIFF
--- a/lib/log/TingClientDrupalWatchDogLogger.php
+++ b/lib/log/TingClientDrupalWatchDogLogger.php
@@ -6,10 +6,23 @@
  * @see http://api.drupal.org/api/function/watchdog/
  */
 class TingClientDrupalWatchDogLogger extends TingClientLogger {
-  public function doLog($message, $severity) {
-    watchdog('ting client', htmlspecialchars($message, ENT_QUOTES, 'UTF-8', FALSE), array(),
-             constant('WATCHDOG_' . $severity),
-             'http://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]);
-  }
-}
 
+  /**
+   * Log a message to the Drupal watchdog.
+   *
+   * @param string $message
+   *   Message to log.
+   * @param string $severity
+   *   Severity to log with.
+   */
+  public function doLog($message, $severity) {
+    watchdog(
+      'ting client',
+      '<pre>@message</pre>',
+      ['@message' => $message],
+      constant('WATCHDOG_' . $severity),
+      'http://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]
+    );
+  }
+
+}


### PR DESCRIPTION
When logging with watchdog, the message is assumed to be a
translatable string. But debugging produces messages too big for the
translation system to handle.

This changes the message to use a placeholder and add the debug
message as a variable.

Also wraps the message in `<pre>` for readability.