### PR TITLE
1493: Do not log infomedia requests because they contain user data

### DIFF
--- a/lib/adapter/TingClientRequestAdapter.php
+++ b/lib/adapter/TingClientRequestAdapter.php
@@ -69,7 +69,13 @@ class TingClientRequestAdapter {
         $stopTime = explode(' ', microtime());
         $time = floatval(($stopTime[1]+$stopTime[0]) - ($startTime[1]+$startTime[0]));
 
-        $this->logger->log('Completed SOAP request ' . $soapAction . ' ' . $request->getWsdlUrl() . ' (' . round($time, 3) . 's). Request body: ' . $client->requestBodyString . ' Response: ' . $response);
+        $requestBodyString = $client->requestBodyString;
+        If ($request instanceof TingClientInfomediaRequest ) {
+          // We can't log the request because it contains user data
+          $requestBodyString = '';
+        }
+
+        $this->logger->log('Completed SOAP request ' . $soapAction . ' ' . $request->getWsdlUrl() . ' (' . round($time, 3) . 's). Request body: ' .  $requestBodyString . ' Response: ' . $response);
 
         // If using JSON and DKABM, we help parse it.
         if ($soapParameters['outputType'] == 'json') {


### PR DESCRIPTION
Issue: https://platform.dandigbib.org/issues/1493

This issue goes against the structure of the client. The logging happens in the Adapter but it is the request object which should handle details about the request. So this PR is to start  a conversation about the right solution. It implements the simplest possible soluation. 

Another solution would be for the reguest object to implement a flag which tells the Adapter if this request can be logged.